### PR TITLE
Issue #3201543 by Aerzas: Order items may not be product variations

### DIFF
--- a/commerce_trustedshops.services.yml
+++ b/commerce_trustedshops.services.yml
@@ -26,4 +26,4 @@ services:
 
   commerce_trustedshops.api.review:
     class: Drupal\commerce_trustedshops\API\Review
-    arguments: ['@commerce_trustedshops.api', '@config.factory']
+    arguments: ['@commerce_trustedshops.api', '@config.factory', '@event_dispatcher']

--- a/src/Event/AlterProductDataEvent.php
+++ b/src/Event/AlterProductDataEvent.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Drupal\commerce_trustedshops\Event;
+
+use Drupal\commerce_order\Entity\OrderItemInterface;
+use Symfony\Component\EventDispatcher\Event;
+
+/**
+ * Event to alter TrustedShops product data.
+ *
+ * Allows to alter the product data before it is sent to TrustedShops.
+ */
+class AlterProductDataEvent extends Event {
+
+  /**
+   * The product data.
+   *
+   * @var string[]
+   */
+  protected $productData;
+
+  /**
+   * The commerce order item entity.
+   *
+   * @var \Drupal\commerce_order\Entity\OrderItemInterface
+   */
+  protected $orderItem;
+
+  /**
+   * Constructs a AlterProductDataEvent object.
+   *
+   * @param string[] $product_data
+   *   The product data.
+   * @param \Drupal\commerce_order\Entity\OrderItemInterface $order_item
+   *   The commerce order item entity.
+   */
+  public function __construct(array $product_data, OrderItemInterface $order_item) {
+    $this->productData = $product_data;
+    $this->orderItem = $order_item;
+  }
+
+  /**
+   * Get product data.
+   *
+   * @return string[]
+   *   The product data.
+   */
+  public function getProductData() {
+    return $this->productData;
+  }
+
+  /**
+   * Set product data.
+   *
+   * @param string[] $product_data
+   *   The product data.
+   */
+  public function setProductData(array $product_data) {
+    $this->productData = $product_data;
+  }
+
+  /**
+   * Get order item.
+   *
+   * @return \Drupal\commerce_order\Entity\OrderItemInterface
+   *   The commerce order item entity.
+   */
+  public function getOrderItem() {
+    return $this->orderItem;
+  }
+
+}

--- a/src/Event/TrustedShopsEvents.php
+++ b/src/Event/TrustedShopsEvents.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Drupal\commerce_trustedshops\Event;
+
+/**
+ * Defines events for the Commerce TrustedShops module.
+ */
+final class TrustedShopsEvents {
+
+  /**
+   * Allows to alter the product data before it is sent to TrustedShops.
+   *
+   * @Event
+   *
+   * @see \Drupal\commerce_trustedshops\Event\AlterProductDataEvent
+   */
+  const ALTER_PRODUCT_DATA = 'commerce_trustedshops.alter_product_data';
+
+}

--- a/tests/src/Kernel/API/ReviewTest.php
+++ b/tests/src/Kernel/API/ReviewTest.php
@@ -27,6 +27,7 @@ class ReviewTest extends APITestBase {
     parent::setUp();
 
     $config_factory = $this->container->get('config.factory');
+    $event_dispatcher = $this->container->get('event_dispatcher');
 
     // Setup dummy TrustedShops Credentials API.
     $config = $config_factory->getEditable('commerce_trustedshops.settings');
@@ -35,7 +36,7 @@ class ReviewTest extends APITestBase {
     $config->set('api.password', 'qwertz');
     $config->save();
 
-    $this->trustedShopsReview = new TrustedShopsReview($this->trustedShops, $config_factory);
+    $this->trustedShopsReview = new TrustedShopsReview($this->trustedShops, $config_factory, $event_dispatcher);
   }
 
   /**

--- a/tests/src/Unit/Event/AlterProductDataEventTest.php
+++ b/tests/src/Unit/Event/AlterProductDataEventTest.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Drupal\Tests\commerce_trustedshops\Unit\Event;
+
+use Drupal\commerce_order\Entity\OrderItemInterface;
+use Drupal\commerce_trustedshops\Event\AlterProductDataEvent;
+use Drupal\Tests\UnitTestCase;
+
+/**
+ * @coversDefaultClass \Drupal\commerce_trustedshops\Event\AlterProductDataEvent
+ *
+ * @group commerce_trustedshops
+ */
+class AlterProductDataEventTest extends UnitTestCase {
+
+  /**
+   * @covers ::getProductData
+   * @covers ::setProductData
+   * @covers ::getOrderItem
+   */
+  public function testEvent() {
+    /** @var \Drupal\commerce_order\Entity\OrderItemInterface $orderItem */
+    $orderItem = $this->prophesize(OrderItemInterface::class)->reveal();
+
+    $event = new AlterProductDataEvent([
+      'name' => 'Initial product',
+      'sku' => 'test-123',
+    ], $orderItem);
+
+    $this->assertEquals([
+      'name' => 'Initial product',
+      'sku' => 'test-123',
+    ], $event->getProductData());
+
+    $event->setProductData([
+      'name' => 'Updated product',
+    ]);
+
+    $this->assertEquals([
+      'name' => 'Updated product',
+    ], $event->getProductData());
+
+    $this->assertInstanceOf(OrderItemInterface::class, $event->getOrderItem());
+  }
+
+}


### PR DESCRIPTION
### 💬 Describe the pull request

<h3 id="summary-problem-motivation">Problem/Motivation</h3>
The <code>Review</code> class which triggers the review makes the assumption that order items have a related product variation. In case of order items with no purchased entity or related to another entity type this raises an error.

<h3 id="summary-proposed-resolution">Proposed resolution</h3>
We could first fill the product data with the order item data and complete with additional information if it is related to a product variation.

<h3 id="summary-remaining-tasks">Remaining tasks</h3>
To go a bit further and allow websites to customize the data sent to TrustedShops we could trigger an event to alter the product data and fill more fields like the brand or the product image.

### 🗃️ Issues
This pull request is related to :
- https://www.drupal.org/node/3201543