### PR TITLE
Issue #3225990 by wengerk, Aerzas: Update PHPUnit tests to match recent Commerce version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,9 @@
 name: Continuous integration
-on: [pull_request]
+on:
+  push:
+  pull_request:
+  schedule:
+    - cron: '0 0 * * THU'
 
 jobs:
   tests:
@@ -9,11 +13,11 @@ jobs:
 
     strategy:
       matrix:
-        drupal_version: ['8.8', '8.9', '9.0']
+        drupal_version: [ '8.8', '8.9', '9.0', '9.1', '9.2' ]
         module: ['commerce_trustedshops']
         experimental: [ false ]
         include:
-          - drupal_version: '9.1'
+          - drupal_version: '9.3'
             module: 'commerce_trustedshops'
             experimental: true
 
@@ -34,11 +38,11 @@ jobs:
 
     strategy:
       matrix:
-        drupal_version: [ '8.8', '8.9', '9.0' ]
+        drupal_version: [ '8.8', '8.9', '9.0', '9.1', '9.2' ]
         module: [ 'commerce_trustedshops' ]
         experimental: [ false ]
         include:
-          - drupal_version: '9.1'
+          - drupal_version: '9.3'
             module: 'commerce_trustedshops'
             experimental: true
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        drupal_version: [ '8.8', '8.9', '9.0', '9.1', '9.2' ]
+        drupal_version: [ '8.9', '9.0', '9.1', '9.2' ]
         module: ['commerce_trustedshops']
         experimental: [ false ]
         include:
@@ -38,7 +38,7 @@ jobs:
 
     strategy:
       matrix:
-        drupal_version: [ '8.8', '8.9', '9.0', '9.1', '9.2' ]
+        drupal_version: [ '8.9', '9.0', '9.1', '9.2' ]
         module: [ 'commerce_trustedshops' ]
         experimental: [ false ]
         include:

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,9 @@ RUN docker-php-ext-install bcmath
 
 ENV COMPOSER_MEMORY_LIMIT=-1
 
+# Disable deprecation notice because of Drupal Commerce hard-dependency.
+ENV SYMFONY_DEPRECATIONS_HELPER=disabled
+
 # Install Drupal Commerce as required by the module
 RUN composer require drupal/commerce:^2.26 'drupal/inline_entity_form:^1.0@RC'
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN docker-php-ext-install bcmath
 ENV COMPOSER_MEMORY_LIMIT=-1
 
 # Install Drupal Commerce as required by the module
-RUN composer require drupal/commerce:^2.20
+RUN composer require drupal/commerce:^2.26
 
 # Install the TrustedShops PHP SDK as required by the module
 RUN composer require antistatique/trustedshops-php-sdk:^1.0.0

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
     volumes:
       # Mount the module in the proper contrib module directory.
       - .:/var/www/html/modules/contrib/commerce_trustedshops
-    restart: always
+    restart: unless-stopped
 
   db:
     image: mariadb:10.3.7
@@ -20,4 +20,4 @@ services:
       MYSQL_PASSWORD: drupal
       MYSQL_DATABASE: drupal
       MYSQL_ROOT_PASSWORD: root
-    restart: always
+    restart: unless-stopped

--- a/src/API/Review.php
+++ b/src/API/Review.php
@@ -111,7 +111,7 @@ class Review {
 
       // Open product data to alterations.
       $event = new AlterProductDataEvent($trusted_product, $order_item);
-      $this->eventDispatcher->dispatch(TrustedShopsEvents::ALTER_PRODUCT_DATA, $event);
+      $this->eventDispatcher->dispatch($event, TrustedShopsEvents::ALTER_PRODUCT_DATA);
 
       $trusted_products[] = $event->getProductData();
     }

--- a/src/API/Review.php
+++ b/src/API/Review.php
@@ -111,7 +111,7 @@ class Review {
 
       // Open product data to alterations.
       $event = new AlterProductDataEvent($trusted_product, $order_item);
-      $this->eventDispatcher->dispatch($event, TrustedShopsEvents::ALTER_PRODUCT_DATA);
+      $this->eventDispatcher->dispatch(TrustedShopsEvents::ALTER_PRODUCT_DATA, $event);
 
       $trusted_products[] = $event->getProductData();
     }

--- a/tests/src/Functional/InviteReviewMultilanguageTest.php
+++ b/tests/src/Functional/InviteReviewMultilanguageTest.php
@@ -49,7 +49,7 @@ class InviteReviewMultilanguageTest extends OrderBrowserTestBase {
   /**
    * {@inheritdoc}
    */
-  protected function setUp() {
+  protected function setUp(): void {
     parent::setUp();
 
     // Add a second language.

--- a/tests/src/Functional/InviteReviewMultilanguageTest.php
+++ b/tests/src/Functional/InviteReviewMultilanguageTest.php
@@ -7,6 +7,7 @@ use Drupal\Tests\commerce_order\Functional\OrderBrowserTestBase;
 use Drupal\commerce_trustedshops\Entity\Shop;
 use Drupal\field\Entity\FieldConfig;
 use Drupal\field\Entity\FieldStorageConfig;
+use Drupal\Tests\commerce_trustedshops\Traits\DeprecationSuppressionTrait;
 
 /**
  * Tests the action to invite a custom to review an order.
@@ -15,6 +16,8 @@ use Drupal\field\Entity\FieldStorageConfig;
  * @group commerce_trustedshops_functional
  */
 class InviteReviewMultilanguageTest extends OrderBrowserTestBase {
+
+  use DeprecationSuppressionTrait;
 
   /**
    * The shop entity.

--- a/tests/src/Functional/InviteReviewTest.php
+++ b/tests/src/Functional/InviteReviewTest.php
@@ -4,6 +4,7 @@ namespace Drupal\Tests\commerce_trustedshops\Functional;
 
 use Drupal\Tests\commerce_order\Functional\OrderBrowserTestBase;
 use Drupal\commerce_trustedshops\Entity\Shop;
+use Drupal\Tests\commerce_trustedshops\Traits\DeprecationSuppressionTrait;
 
 /**
  * Tests the action to invite a custom to review an order.
@@ -12,6 +13,7 @@ use Drupal\commerce_trustedshops\Entity\Shop;
  * @group commerce_trustedshops_functional
  */
 class InviteReviewTest extends OrderBrowserTestBase {
+  use DeprecationSuppressionTrait;
 
   /**
    * The shop entity.

--- a/tests/src/Functional/InviteReviewTest.php
+++ b/tests/src/Functional/InviteReviewTest.php
@@ -44,7 +44,7 @@ class InviteReviewTest extends OrderBrowserTestBase {
   /**
    * {@inheritdoc}
    */
-  protected function setUp() {
+  protected function setUp(): void {
     parent::setUp();
 
     // Setup dummy TrustedShops Credentials API.

--- a/tests/src/Functional/ShopAdminTest.php
+++ b/tests/src/Functional/ShopAdminTest.php
@@ -4,6 +4,7 @@ namespace Drupal\Tests\commerce_trustedshops\Functional;
 
 use Drupal\Tests\commerce\Functional\CommerceBrowserTestBase;
 use Drupal\commerce_trustedshops\Entity\Shop;
+use Drupal\Tests\commerce_trustedshops\Traits\DeprecationSuppressionTrait;
 
 /**
  * Tests the commerce_trustedshops_shop entity forms.
@@ -12,6 +13,7 @@ use Drupal\commerce_trustedshops\Entity\Shop;
  * @group commerce_trustedshops_functional
  */
 class ShopAdminTest extends CommerceBrowserTestBase {
+  use DeprecationSuppressionTrait;
 
   /**
    * Modules to enable.

--- a/tests/src/Kernel/API/APITestBase.php
+++ b/tests/src/Kernel/API/APITestBase.php
@@ -59,7 +59,7 @@ abstract class APITestBase extends CommerceKernelTestBase {
   /**
    * {@inheritdoc}
    */
-  protected function setUp() {
+  protected function setUp(): void {
     parent::setUp();
 
     $this->installEntitySchema('profile');

--- a/tests/src/Kernel/API/APITestBase.php
+++ b/tests/src/Kernel/API/APITestBase.php
@@ -11,11 +11,14 @@ use Drupal\commerce_product\Entity\ProductVariation;
 use Drupal\commerce_product\Entity\ProductVariationType;
 use Drupal\profile\Entity\Profile;
 use Drupal\Tests\commerce\Kernel\CommerceKernelTestBase;
+use Drupal\Tests\commerce_trustedshops\Traits\DeprecationSuppressionTrait;
 
 /**
  * Provides a base class for Commerce kernel tests.
  */
 abstract class APITestBase extends CommerceKernelTestBase {
+
+  use DeprecationSuppressionTrait;
 
   /**
    * The shop entity.

--- a/tests/src/Kernel/API/ReviewTest.php
+++ b/tests/src/Kernel/API/ReviewTest.php
@@ -64,7 +64,7 @@ class ReviewTest extends APITestBase {
     $now->setTimezone(new \DateTimeZone('UTC'));
 
     $this->eventDispatcher
-      ->dispatch(TrustedShopsEvents::ALTER_PRODUCT_DATA, Argument::type(AlterProductDataEvent::class))
+      ->dispatch(Argument::type(AlterProductDataEvent::class), TrustedShopsEvents::ALTER_PRODUCT_DATA)
       ->shouldBeCalled();
 
     $this->trustedShops->expects($this->once())->method('post')

--- a/tests/src/Kernel/API/ReviewTest.php
+++ b/tests/src/Kernel/API/ReviewTest.php
@@ -34,7 +34,7 @@ class ReviewTest extends APITestBase {
   /**
    * {@inheritdoc}
    */
-  protected function setUp() {
+  protected function setUp(): void {
     parent::setUp();
 
     $config_factory = $this->container->get('config.factory');

--- a/tests/src/Kernel/API/ReviewTest.php
+++ b/tests/src/Kernel/API/ReviewTest.php
@@ -64,7 +64,7 @@ class ReviewTest extends APITestBase {
     $now->setTimezone(new \DateTimeZone('UTC'));
 
     $this->eventDispatcher
-      ->dispatch(Argument::type(AlterProductDataEvent::class), TrustedShopsEvents::ALTER_PRODUCT_DATA)
+      ->dispatch(TrustedShopsEvents::ALTER_PRODUCT_DATA, Argument::type(AlterProductDataEvent::class))
       ->shouldBeCalled();
 
     $this->trustedShops->expects($this->once())->method('post')

--- a/tests/src/Kernel/CheckoutPane/ReviewCollectorTest.php
+++ b/tests/src/Kernel/CheckoutPane/ReviewCollectorTest.php
@@ -11,6 +11,7 @@ use Drupal\commerce_product\Entity\Product;
 use Drupal\commerce_product\Entity\ProductVariation;
 use Drupal\commerce_product\Entity\ProductVariationType;
 use Drupal\profile\Entity\Profile;
+use Drupal\Tests\commerce_trustedshops\Traits\DeprecationSuppressionTrait;
 
 /**
  * @coversDefaultClass \Drupal\commerce_trustedshops\Plugin\Commerce\CheckoutPane\ReviewCollector
@@ -18,6 +19,7 @@ use Drupal\profile\Entity\Profile;
  * @group commerce_trustedshops
  */
 class ReviewCollectorTest extends DrupalCommerceKernelTestBase {
+  use DeprecationSuppressionTrait;
 
   /**
    * The shop entity.

--- a/tests/src/Kernel/CheckoutPane/ReviewCollectorTest.php
+++ b/tests/src/Kernel/CheckoutPane/ReviewCollectorTest.php
@@ -61,7 +61,7 @@ class ReviewCollectorTest extends DrupalCommerceKernelTestBase {
   /**
    * {@inheritdoc}
    */
-  protected function setUp() {
+  protected function setUp(): void {
     parent::setUp();
 
     $this->renderer = $this->container->get('renderer');

--- a/tests/src/Kernel/DefaultOrderLanguageResolverTest.php
+++ b/tests/src/Kernel/DefaultOrderLanguageResolverTest.php
@@ -85,7 +85,7 @@ class DefaultOrderLanguageResolverTest extends DrupalCommerceKernelTestBase {
   /**
    * {@inheritdoc}
    */
-  protected function setUp() {
+  protected function setUp(): void {
     parent::setUp();
     $this->setupMultilingual();
 

--- a/tests/src/Kernel/DefaultOrderLanguageResolverTest.php
+++ b/tests/src/Kernel/DefaultOrderLanguageResolverTest.php
@@ -16,6 +16,7 @@ use Drupal\field\Entity\FieldStorageConfig;
 use Drupal\profile\Entity\Profile;
 use Drupal\Tests\commerce\Kernel\CommerceKernelTestBase as DrupalCommerceKernelTestBase;
 use Drupal\language\Entity\ConfigurableLanguage;
+use Drupal\Tests\commerce_trustedshops\Traits\DeprecationSuppressionTrait;
 
 /**
  * @coversDefaultClass \Drupal\commerce_trustedshops\Resolver\OrderLanguage\DefaultOrderLanguageResolver
@@ -23,6 +24,7 @@ use Drupal\language\Entity\ConfigurableLanguage;
  * @group commerce_trustedshops
  */
 class DefaultOrderLanguageResolverTest extends DrupalCommerceKernelTestBase {
+  use DeprecationSuppressionTrait;
 
   /**
    * The Entity Type Manager.

--- a/tests/src/Kernel/DefaultShopResolverTest.php
+++ b/tests/src/Kernel/DefaultShopResolverTest.php
@@ -59,7 +59,7 @@ class DefaultShopResolverTest extends DrupalCommerceKernelTestBase {
   /**
    * {@inheritdoc}
    */
-  protected function setUp() {
+  protected function setUp(): void {
     parent::setUp();
 
     $this->installEntitySchema('commerce_trustedshops_shop');

--- a/tests/src/Kernel/DefaultShopResolverTest.php
+++ b/tests/src/Kernel/DefaultShopResolverTest.php
@@ -120,8 +120,8 @@ class DefaultShopResolverTest extends DrupalCommerceKernelTestBase {
     $shop = $this->defaultShopResolver->resolve($context);
     $expected_shop = $shop_storage->load($expected_shop_id);
 
-    $this->assertEqual($shop->id(), $expected_shop->id());
-    $this->assertEqual($shop->get('tsid')->value, $expected_tsid);
+    $this->assertEquals($shop->id(), $expected_shop->id());
+    $this->assertEquals($shop->get('tsid')->value, $expected_tsid);
   }
 
   /**
@@ -151,7 +151,7 @@ class DefaultShopResolverTest extends DrupalCommerceKernelTestBase {
     $shop = $this->defaultShopResolver->resolve();
     $shop_storage = $this->entityTypeManager->getStorage('commerce_trustedshops_shop');
     $expected_shop = $shop_storage->load($this->testShops[1]->id());
-    $this->assertEqual($expected_shop, $shop);
+    $this->assertEquals($expected_shop, $shop);
   }
 
   /**

--- a/tests/src/Kernel/DefaultShopResolverTest.php
+++ b/tests/src/Kernel/DefaultShopResolverTest.php
@@ -7,6 +7,7 @@ use Drupal\Core\Language\Language;
 use Drupal\Core\Language\LanguageInterface;
 use Drupal\Tests\commerce\Kernel\CommerceKernelTestBase as DrupalCommerceKernelTestBase;
 use Drupal\language\Entity\ConfigurableLanguage;
+use Drupal\Tests\commerce_trustedshops\Traits\DeprecationSuppressionTrait;
 
 /**
  * @coversDefaultClass \Drupal\commerce_trustedshops\Resolver\Shop\DefaultShopResolver
@@ -14,6 +15,7 @@ use Drupal\language\Entity\ConfigurableLanguage;
  * @group commerce_trustedshops
  */
 class DefaultShopResolverTest extends DrupalCommerceKernelTestBase {
+  use DeprecationSuppressionTrait;
 
   /**
    * The Entity Type Manager.

--- a/tests/src/Kernel/Entity/ShopTest.php
+++ b/tests/src/Kernel/Entity/ShopTest.php
@@ -33,7 +33,7 @@ class ShopTest extends CommerceKernelTestBase {
   /**
    * {@inheritdoc}
    */
-  protected function setUp() {
+  protected function setUp(): void {
     parent::setUp();
 
     $this->installEntitySchema('commerce_trustedshops_shop');

--- a/tests/src/Kernel/Entity/ShopTest.php
+++ b/tests/src/Kernel/Entity/ShopTest.php
@@ -4,6 +4,7 @@ namespace Drupal\Tests\commerce_trustedshops\Kernel\Entity;
 
 use Drupal\Tests\commerce\Kernel\CommerceKernelTestBase;
 use Drupal\commerce_trustedshops\Entity\Shop;
+use Drupal\Tests\commerce_trustedshops\Traits\DeprecationSuppressionTrait;
 
 /**
  * Tests the Shop entity.
@@ -13,6 +14,8 @@ use Drupal\commerce_trustedshops\Entity\Shop;
  * @group commerce_trustedshops
  */
 class ShopTest extends CommerceKernelTestBase {
+
+  use DeprecationSuppressionTrait;
 
   /**
    * A sample user.

--- a/tests/src/Traits/DeprecationSuppressionTrait.php
+++ b/tests/src/Traits/DeprecationSuppressionTrait.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Drupal\Tests\commerce_trustedshops\Traits;
+
+/**
+ * Original DeprecationSuppressionTrait of Drupal Commerce is not compatible
+ * with PHP 8.
+ *
+ * @see \Drupal\Tests\commerce\Traits\DeprecationSuppressionTrait;
+ */
+trait DeprecationSuppressionTrait {
+
+  /**
+   * Sets an error handler to suppress specified deprecation messages.
+   */
+  protected function setErrorHandler() {
+    $previous_error_handler = set_error_handler(function ($severity, $message, $file, $line) use (&$previous_error_handler) {
+
+      $skipped_deprecations = [
+        // @see https://www.drupal.org/project/address/issues/3089266
+        'Theme functions are deprecated in drupal:8.0.0 and are removed from drupal:10.0.0. Use Twig templates instead of theme_inline_entity_form_entity_table(). See https://www.drupal.org/node/1831138',
+      ];
+
+      if (!in_array($message, $skipped_deprecations, TRUE)) {
+        return $previous_error_handler($severity, $message, $file, $line);
+      }
+    }, E_USER_DEPRECATED);
+  }
+
+  /**
+   * Restores the original error handler.
+   */
+  protected function restoreErrorHandler() {
+    restore_error_handler();
+  }
+
+}

--- a/tests/src/Traits/DeprecationSuppressionTrait.php
+++ b/tests/src/Traits/DeprecationSuppressionTrait.php
@@ -3,8 +3,10 @@
 namespace Drupal\Tests\commerce_trustedshops\Traits;
 
 /**
- * Original DeprecationSuppressionTrait of Drupal Commerce is not compatible
- * with PHP 8.
+ * Override DeprecationSuppressionTrait of Drupal Commerce.
+ *
+ * The original DeprecationSuppressionTrait from Drupal Commerce is not
+ * compatible with PHP 8.
  *
  * @see \Drupal\Tests\commerce\Traits\DeprecationSuppressionTrait;
  */

--- a/tests/src/Unit/Resolver/ChainOrderLanguageResolverTest.php
+++ b/tests/src/Unit/Resolver/ChainOrderLanguageResolverTest.php
@@ -24,7 +24,7 @@ class ChainOrderLanguageResolverTest extends UnitTestCase {
   /**
    * {@inheritdoc}
    */
-  public function setUp() {
+  public function setUp(): void {
     parent::setUp();
     $this->resolver = new ChainOrderLanguageResolver();
   }

--- a/tests/src/Unit/Resolver/ChainShopResolverTest.php
+++ b/tests/src/Unit/Resolver/ChainShopResolverTest.php
@@ -23,7 +23,7 @@ class ChainShopResolverTest extends UnitTestCase {
   /**
    * {@inheritdoc}
    */
-  public function setUp() {
+  public function setUp(): void {
     parent::setUp();
     $this->resolver = new ChainShopResolver();
   }


### PR DESCRIPTION
### 💬 Describe the pull request
- fix deprecation notices
- set github actions schedule & tests on Drupal 8.8 to 9.3
- update docker from restart always to unless-stopped