### PR TITLE
update antistatique/trustedshops-php-sdk (1.0.0 => 1.1.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Security
+- update antistatique/trustedshops-php-sdk (1.0.0 => 1.1.0)
 
 ## [3.0.1] - 2024-06-25
 ### Removed

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
   "prefer-stable": true,
   "require": {
     "drupal/commerce": "^2.8",
-    "antistatique/trustedshops-php-sdk": "^1.0.0"
+    "antistatique/trustedshops-php-sdk": "^1.1.0"
   },
   "require-dev": {
       "drupal/coder": "^8.3.1"


### PR DESCRIPTION
### 💬 Description
update antistatique/trustedshops-php-sdk (1.0.0 => 1.1.0)

- [x] Update the "Unreleased" section of the `CHANGELOG.md` with [chan](https://github.com/geut/chan/tree/main/packages/chan)
