### PR TITLE
drop support of older that Drupal 10.5 version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,14 +12,17 @@ jobs:
 
     strategy:
       matrix:
-        drupal_version: ['10.3', '10.4', '11.0', '11.1']
+        drupal_version: ['10.5', '11.0', '11.1']
         module: ['commerce_trustedshops']
         experimental: [ false ]
         include:
-          - drupal_version: '10.5'
+          - drupal_version: '10.6'
             module: 'commerce_trustedshops'
             experimental: true
-          - drupal_version: '11.2'
+         - drupal_version: '11.2'
+            module: 'commerce_trustedshops'
+            experimental: true
+          - drupal_version: '11.3'
             module: 'commerce_trustedshops'
             experimental: true
 
@@ -46,14 +49,17 @@ jobs:
 
     strategy:
       matrix:
-        drupal_version: ['10.3', '10.4', '11.0', '11.1']
+        drupal_version: ['10.5', '11.0', '11.1']
         module: [ 'commerce_trustedshops' ]
         experimental: [false]
         include:
-          - drupal_version: '10.5'
+          - drupal_version: '10.6'
             module: 'commerce_trustedshops'
             experimental: true
-          - drupal_version: '11.2'
+         - drupal_version: '11.2'
+            module: 'commerce_trustedshops'
+            experimental: true
+          - drupal_version: '11.3'
             module: 'commerce_trustedshops'
             experimental: true
 
@@ -83,7 +89,7 @@ jobs:
 
     strategy:
       matrix:
-        drupal_version: ['10.4']
+        drupal_version: ['10.5']
         module: ['commerce_trustedshops']
 
     steps:

--- a/.github/workflows/styles.yml
+++ b/.github/workflows/styles.yml
@@ -9,7 +9,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.1'
+          php-version: '8.3'
           extensions: mbstring, intl, gd, xml, dom, json, fileinfo, curl, zip, iconv
           tools: cs2pr, composer:v2
       - uses: actions/checkout@v4
@@ -23,7 +23,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.1'
+          php-version: '8.3'
           extensions: mbstring, intl, gd, xml, dom, json, fileinfo, curl, zip, iconv
           tools: cs2pr, composer:v2, phpmd
       - uses: actions/checkout@v4
@@ -37,7 +37,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.1'
+          php-version: '8.3'
           extensions: mbstring, intl, gd, xml, dom, json, fileinfo, curl, zip, iconv
           tools: cs2pr, composer:v2, phpcpd
       - uses: actions/checkout@v4

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -32,18 +32,13 @@ variables:
   SKIP_ESLINT: '1'
   # Opt in to testing current minor against max supported PHP version.
   OPT_IN_TEST_MAX_PHP: '1'
-  # Opt in to testing previous minor (Drupal 11.0.x).
+  # Opt in to testing previous minor (Drupal 11.1.x)
   OPT_IN_TEST_PREVIOUS_MINOR: '1'
-  # Opt in to testing next minor (Drupal 11.2.x).
+  # Opt in to testing next minor (Drupal 11.3.x).
   OPT_IN_TEST_NEXT_MINOR: '1'
-
-  # Opt in to testing $CORE_PREVIOUS_MAJOR (currently Drupal 10.4).
+  # Opt in to testing $CORE_PREVIOUS_MAJOR (Drupal 10.4.x).
   OPT_IN_TEST_PREVIOUS_MAJOR: '1'
-
-  # The 3.x branch of the module requires PHP >=8.1, rather than core's >=7.4.
-  CORE_PREVIOUS_PHP_MIN: '8.1'
-
-  # Opt in to testing $CORE_MAJOR_DEVELOPMENT (currently Drupal 11).
+  # Opt in to testing $CORE_MAJOR_DEVELOPMENT (Drupal 12).
   OPT_IN_TEST_NEXT_MAJOR: '1'
 
 # This module wants to strictly comply with Drupal's coding standards.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- add official support of drupal 10.5
+
+### Removed
+- drop coverage of Drupal 10.0.x
+- drop coverage of Drupal 10.1.x
+- drop coverage of Drupal 10.2.x
+- drop coverage of Drupal 10.3.x
+- drop coverage of Drupal 10.4.x
 
 ## [3.1.0] - 2025-03-21
 ### Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,7 +33,7 @@ globally on your environment:
 
 Once run, you will be able to access to your fresh installed Drupal on `localhost::8888`.
 
-    docker compose build --pull --build-arg BASE_IMAGE_TAG=10.4 drupal
+    docker compose build --pull --build-arg BASE_IMAGE_TAG=11.2 drupal
     (get a coffee, this will take some time...)
     docker compose up -d drupal
     docker compose exec -u www-data drupal drush site-install standard --db-url="mysql://drupal:drupal@db/drupal" -y

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE_TAG=10.4
+ARG BASE_IMAGE_TAG=11.2
 FROM wengerk/drupal-for-contrib:${BASE_IMAGE_TAG}
 
 # Drupal Commerce 2.20+ requires bcmath extensions.

--- a/commerce_trustedshops.info.yml
+++ b/commerce_trustedshops.info.yml
@@ -2,7 +2,7 @@ name: Commerce TrustedShops
 description: 'Provides Commerce integration for TrustedShops.'
 package: 'Commerce (contrib)'
 type: module
-core_version_requirement: ^10 || ^11
+core_version_requirement: ^10.5 || ^11
 
 dependencies:
   - drupal:commerce

--- a/tests/modules/commerce_trustedshops_test/commerce_trustedshops_test.info.yml
+++ b/tests/modules/commerce_trustedshops_test/commerce_trustedshops_test.info.yml
@@ -2,7 +2,7 @@ name: Commerce TrustedShops Test
 description: 'Support module for Commerce TrustedShops.'
 package: Testing
 type: module
-core_version_requirement: ^9.5 || ^10 || ^11
+core_version_requirement: ^10.5 || ^11
 
 dependencies:
   - drupal:commerce_trustedshops


### PR DESCRIPTION
### 💬 Description
drop support of older that Drupal 10.5 version

- [x] Update the "Unreleased" section of the `CHANGELOG.md` with [chan](https://github.com/geut/chan/tree/main/packages/chan)